### PR TITLE
fix(helper): update how to use settings variables

### DIFF
--- a/catalogue/helpers.py
+++ b/catalogue/helpers.py
@@ -1,9 +1,9 @@
 import httpx
 
-from django_imdb.settings import DJANGO_IMDB_OMDB_API_KEY
+from django.conf import settings
 
 
 def get_imdb_info(imdb_id):
-    url = f"https://www.omdbapi.com/?apikey={DJANGO_IMDB_OMDB_API_KEY}&i={imdb_id}"
+    url = f"https://www.omdbapi.com/?apikey={settings.DJANGO_IMDB_OMDB_API_KEY}&i={imdb_id}"
     response = httpx.get(url)
     return response.json()


### PR DESCRIPTION
The best practice is to not use `app.settings` module for using settings variables. Instead, we should use `from django.conf import settings` , which provides settings as an object.

[Django Docs](https://docs.djangoproject.com/en/4.2/topics/settings/#using-settings-in-python-code)
[StackOverflow Descriptions](https://stackoverflow.com/questions/7867797/how-do-i-reference-a-django-settings-variable-in-my-models-py)